### PR TITLE
Update debian versions

### DIFF
--- a/lib/facter/initsystem.rb
+++ b/lib/facter/initsystem.rb
@@ -88,10 +88,12 @@ def initsystem_curated
 
     when 'Debian'
       case Facter.value(:operatingsystemmajrelease)
+      when '6'
+        'sysvinit'
       when '7'
         'sysvinit'
       when '8'
-        'sysvinit'
+        'systemd'
       else
         '' # No match, fall back to auto-resolving
       end


### PR DESCRIPTION
Debian 8 jessie uses systemd as default init system(https://www.debian.org/releases/stable/i386/release-notes/ch-whats-new.en.html#systemd)
Also, debian 6 squeeze have long-term-support until feb 2016
